### PR TITLE
feat(mobile): full mobile responsiveness across all pages and routes

### DIFF
--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -24,17 +24,7 @@ function stateColor(state: MatchState) {
   return state === 'in' ? 'var(--live)' : 'var(--ink-3)';
 }
 
-function useIsMobile(bp = 768) {
-  const [v, setV] = useState(false);
-  useEffect(() => {
-    const mq = window.matchMedia(`(max-width: ${bp - 1}px)`);
-    setV(mq.matches);
-    const h = (e: MediaQueryListEvent) => setV(e.matches);
-    mq.addEventListener('change', h);
-    return () => mq.removeEventListener('change', h);
-  }, [bp]);
-  return v;
-}
+import { useIsMobile } from '@/hooks/useWindowWidth';
 
 // ── Stat card ─────────────────────────────────────────────────────────────────
 
@@ -1071,7 +1061,7 @@ function SimulateTab({
 type AdminTab = 'monitor' | 'simulate';
 
 export default function AdminDashboard() {
-  const isMobile = useIsMobile();
+  const isMobile = useIsMobile(768);
   const router = useRouter();
 
   const [activeTab, setActiveTab] = useState<AdminTab>('monitor');

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -767,6 +767,20 @@ body {
   .my-team-name { max-width: 84px; }
 }
 
+/* ── mobile polish ── */
+@media (max-width: 640px) {
+  /* Bracket hero */
+  .bracket-hero { padding: 28px 16px 20px !important; }
+  .bracket-headline { font-size: 40px !important; }
+  .bracket-stages { gap: 6px !important; }
+
+  /* Tab bars with overflow-x scroll */
+  .topbar-mid { -webkit-overflow-scrolling: touch; }
+
+  /* Ensure no page content bleeds outside viewport */
+  .screen { max-width: 100vw; overflow-x: hidden; }
+}
+
 /* knockout bracket */
 .bracket-screen {
   --bracket-line: rgba(200, 147, 42, 0.55);

--- a/frontend/app/match/[id]/page.tsx
+++ b/frontend/app/match/[id]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState, useCallback, useRef } from 'react';
+import { useIsMobile } from '@/hooks/useWindowWidth';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { useGoalCelebration } from '@/components/LiveGoalCelebration';
@@ -129,17 +130,6 @@ interface H2HGame {
 
 // ── Hooks ─────────────────────────────────────────────────────────────────────
 
-function useIsMobile(breakpoint = 640) {
-  const [isMobile, setIsMobile] = useState(false);
-  useEffect(() => {
-    const mq = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
-    setIsMobile(mq.matches);
-    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
-    mq.addEventListener('change', handler);
-    return () => mq.removeEventListener('change', handler);
-  }, [breakpoint]);
-  return isMobile;
-}
 
 function useCountdown(dateStr: string): number | null {
   const [ms, setMs] = useState<number | null>(null);

--- a/frontend/app/test-mls/[slug]/page.tsx
+++ b/frontend/app/test-mls/[slug]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState, useCallback, useRef } from 'react';
+import { useIsMobile } from '@/hooks/useWindowWidth';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { useGoalCelebration } from '@/components/LiveGoalCelebration';
@@ -156,18 +157,6 @@ interface MLSMatchData {
 }
 
 // ── Hooks ─────────────────────────────────────────────────────────────────────
-
-function useIsMobile(breakpoint = 640) {
-  const [isMobile, setIsMobile] = useState(false);
-  useEffect(() => {
-    const mq = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
-    setIsMobile(mq.matches);
-    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
-    mq.addEventListener('change', handler);
-    return () => mq.removeEventListener('change', handler);
-  }, [breakpoint]);
-  return isMobile;
-}
 
 function useCountdown(dateStr: string): number | null {
   const [ms, setMs] = useState<number | null>(null);

--- a/frontend/components/CountryView.tsx
+++ b/frontend/components/CountryView.tsx
@@ -4,9 +4,14 @@ import Link from 'next/link';
 import { countries, stadiums, matches } from '@/lib/data';
 import { BackBar } from './Shared';
 import type { CountryCode } from '@/lib/types';
+import { useWindowWidth } from '@/hooks/useWindowWidth';
 
 export function CountryView({ code }: { code: string }) {
   const c = countries[code as CountryCode];
+  const width = useWindowWidth();
+  const isMobile = width < 640;
+  const isTablet = width < 1024;
+  const pad = isMobile ? '16px' : isTablet ? '24px' : '56px';
   if (!c) return <div style={{ padding: 60 }}>Country not found</div>;
   const cs = stadiums.filter((s) => s.country === code);
   const matchesHere = matches.filter((m) => cs.some((s) => s.id === m.stadium));
@@ -17,18 +22,18 @@ export function CountryView({ code }: { code: string }) {
 
       <div style={{
         position: 'relative',
-        padding: '64px 56px',
+        padding: isMobile ? '40px 16px' : `64px ${pad}`,
         background: `linear-gradient(135deg, ${c.colors[0]} 0%, ${c.colors[1] || c.colors[0]} 100%)`,
         color: '#fff', overflow: 'hidden',
       }}>
         <div style={{ position: 'absolute', inset: 0, background: 'radial-gradient(rgba(255,255,255,0.05) 1px, transparent 1px)', backgroundSize: '6px 6px', opacity: 0.5 }} />
-        <div style={{ position: 'relative', display: 'grid', gridTemplateColumns: '2fr 1fr', gap: 48, alignItems: 'flex-end' }}>
+        <div style={{ position: 'relative', display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '2fr 1fr', gap: isMobile ? 24 : 48, alignItems: 'flex-end' }}>
           <div>
             <div className="mono" style={{ fontSize: 10, letterSpacing: '0.22em', opacity: 0.85 }}>HOST NATION</div>
-            <div className="serif" style={{ fontSize: 120, lineHeight: 0.92, marginTop: 14, letterSpacing: '-0.03em' }}>{c.name}</div>
-            <div className="serif it" style={{ fontSize: 26, marginTop: 18, opacity: 0.9 }}>&ldquo;{c.tagline}&rdquo;</div>
+            <div className="serif" style={{ fontSize: isMobile ? 64 : isTablet ? 88 : 120, lineHeight: 0.92, marginTop: 14, letterSpacing: '-0.03em' }}>{c.name}</div>
+            <div className="serif it" style={{ fontSize: isMobile ? 18 : 26, marginTop: 18, opacity: 0.9 }}>&ldquo;{c.tagline}&rdquo;</div>
           </div>
-          <div style={{ borderLeft: '1px solid rgba(255,255,255,0.3)', paddingLeft: 28 }}>
+          <div style={{ borderLeft: isMobile ? 'none' : '1px solid rgba(255,255,255,0.3)', borderTop: isMobile ? '1px solid rgba(255,255,255,0.3)' : 'none', paddingLeft: isMobile ? 0 : 28, paddingTop: isMobile ? 20 : 0 }}>
             <KV label="Cities" v={cs.length} />
             <KV label="Stadia" v={cs.length} />
             <KV label="Population" v={c.population} />
@@ -38,7 +43,7 @@ export function CountryView({ code }: { code: string }) {
         </div>
       </div>
 
-      <div style={{ padding: '48px 56px', display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 56 }}>
+      <div style={{ padding: isMobile ? '32px 16px' : `48px ${pad}`, display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr', gap: isMobile ? 32 : 56 }}>
         <div>
           <div className="eyebrow">What to eat</div>
           <div className="serif it" style={{ fontSize: 26, marginTop: 6, marginBottom: 22 }}>Food worth a detour</div>
@@ -72,9 +77,9 @@ export function CountryView({ code }: { code: string }) {
         </div>
       </div>
 
-      <div style={{ padding: '0 56px 64px' }}>
+      <div style={{ padding: isMobile ? `0 16px 48px` : `0 ${pad} 64px` }}>
         <div className="eyebrow">{cs.length} {cs.length === 1 ? 'stadium' : 'stadia'} in {c.name}</div>
-        <div style={{ marginTop: 18, display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: 14 }}>
+        <div style={{ marginTop: 18, display: 'grid', gridTemplateColumns: `repeat(auto-fill, minmax(min(220px, 100%), 1fr))`, gap: 14 }}>
           {cs.map((s) => (
             <Link key={s.id} href={`/stadium/${s.id}`} style={{
               cursor: 'pointer', textDecoration: 'none', color: 'inherit',

--- a/frontend/components/MatchDetail.tsx
+++ b/frontend/components/MatchDetail.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { BackBar } from './Shared';
+import { useWindowWidth } from '@/hooks/useWindowWidth';
 import { MatchPrediction } from './MatchPrediction';
 import { useTweaks } from './Providers';
 import { useTypewriter } from '@/hooks/useTypewriter';
@@ -16,6 +17,10 @@ import { FotmobMatchExtrasBlock } from './FotmobMatchExtras';
 
 export function MatchDetail({ id }: { id: string }) {
   const { tweaks } = useTweaks();
+  const width = useWindowWidth();
+  const isMobile = width < 640;
+  const isTablet = width < 1024;
+  const pad = isMobile ? '16px' : isTablet ? '32px' : '56px';
   const [detail, setDetail] = useState<EspnMatchDetail | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [loadingMatch, setLoadingMatch] = useState(true);
@@ -160,17 +165,29 @@ export function MatchDetail({ id }: { id: string }) {
 
       <div
         style={{
-          padding: '48px 56px 40px',
+          padding: isMobile ? '24px 16px 20px' : `48px ${pad} 40px`,
           display: 'grid',
-          gridTemplateColumns: '1fr auto 1fr',
-          gap: 40,
+          gridTemplateColumns: isMobile ? '1fr' : '1fr auto 1fr',
+          gap: isMobile ? 0 : 40,
           alignItems: 'center',
           borderBottom: '1px solid var(--rule)',
         }}
       >
-        <TeamHero team={detail.homeTeam} side="left" state={detail.state} />
-        <StatusCenter detail={detail} />
-        <TeamHero team={detail.awayTeam} side="right" state={detail.state} />
+        {isMobile ? (
+          <>
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 16, textAlign: 'center' }}>
+              <TeamHero team={detail.homeTeam} side="left" state={detail.state} />
+              <StatusCenter detail={detail} />
+              <TeamHero team={detail.awayTeam} side="right" state={detail.state} />
+            </div>
+          </>
+        ) : (
+          <>
+            <TeamHero team={detail.homeTeam} side="left" state={detail.state} />
+            <StatusCenter detail={detail} />
+            <TeamHero team={detail.awayTeam} side="right" state={detail.state} />
+          </>
+        )}
       </div>
 
       <div
@@ -182,7 +199,7 @@ export function MatchDetail({ id }: { id: string }) {
         }}
       >
 
-        <div style={{ padding: '32px 48px', display: 'flex', flexDirection: 'column', gap: 32 }}>
+        <div style={{ padding: isMobile ? `24px 16px` : `32px ${pad}`, display: 'flex', flexDirection: 'column', gap: 32 }}>
           {tweaks.aiSummary && narrativeText && (
             <div style={{ background: 'var(--ink)', color: 'var(--paper)', padding: 24, borderRadius: 14 }}>
               <div

--- a/frontend/components/MatchesList.tsx
+++ b/frontend/components/MatchesList.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 
 import { stadiums } from '@/lib/data';
 import { Flag } from './Shared';
+import { useWindowWidth } from '@/hooks/useWindowWidth';
 
 const filters = [
   { id: 'all', label: 'All' },
@@ -27,17 +28,6 @@ const ROUNDS = [
 
 type FilterId = 'all' | 'live' | 'upcoming' | 'ft';
 
-function useWindowWidth() {
-  const [width, setWidth] = useState(
-    typeof window !== 'undefined' ? window.innerWidth : 1024
-  );
-  useEffect(() => {
-    const handler = () => setWidth(window.innerWidth);
-    window.addEventListener('resize', handler);
-    return () => window.removeEventListener('resize', handler);
-  }, []);
-  return width;
-}
 
 export function MatchesList() {
   const [filter, setFilter] = useState<FilterId>('all');

--- a/frontend/components/MyWorldCup.tsx
+++ b/frontend/components/MyWorldCup.tsx
@@ -4,18 +4,23 @@ import Link from 'next/link';
 import { teams } from '@/lib/data';
 import { Flag, BackBar } from './Shared';
 import { useMyTeam } from './Providers';
+import { useWindowWidth } from '@/hooks/useWindowWidth';
 
 export function MyWorldCup() {
   const { myTeam, setMyTeam } = useMyTeam();
   const all = Object.values(teams);
+  const width = useWindowWidth();
+  const isMobile = width < 640;
+  const isTablet = width < 1024;
+  const pad = isMobile ? '16px' : isTablet ? '24px' : '56px';
 
   return (
     <div className="screen" style={{ minHeight: 'calc(100vh - 64px)' }}>
       <BackBar label="MY WORLD CUP" />
-      <div style={{ padding: '48px 56px', display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 56 }}>
+      <div style={{ padding: `48px ${pad}`, display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr', gap: isMobile ? 32 : 56 }}>
         <div>
           <div className="eyebrow">My World Cup</div>
-          <div className="headline" style={{ fontSize: 64, marginTop: 12 }}>
+          <div className="headline" style={{ fontSize: isMobile ? 40 : isTablet ? 52 : 64, marginTop: 12 }}>
             Pick a team.<br /><em>The whole app adapts.</em>
           </div>
           <div className="serif it" style={{ fontSize: 19, color: 'var(--ink-3)', marginTop: 22, maxWidth: 480, lineHeight: 1.5 }}>
@@ -59,8 +64,8 @@ export function MyWorldCup() {
           <div style={{
             marginTop: 18,
             display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))',
-            gap: 8, maxHeight: 560, overflow: 'auto', paddingRight: 4,
+            gridTemplateColumns: 'repeat(auto-fill, minmax(min(140px, 100%), 1fr))',
+            gap: 8, maxHeight: isMobile ? 'none' : 560, overflow: isMobile ? 'visible' : 'auto', paddingRight: 4,
           }}>
             {all.map((t) => (
               <div key={t.code} onClick={() => setMyTeam(t.code)} role="button" tabIndex={0} onKeyDown={(e) => { if (e.key === 'Enter') setMyTeam(t.code); }} style={{

--- a/frontend/components/News.tsx
+++ b/frontend/components/News.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState, useMemo } from 'react';
+import { useWindowWidth } from '@/hooks/useWindowWidth';
 
 interface Article {
   id: string;
@@ -89,18 +90,6 @@ function ArticleLink({ article, style, children }: { article: Article; style?: R
   return <div style={style}>{children}</div>;
 }
 
-// Simple hook to track viewport width
-function useWindowWidth() {
-  const [width, setWidth] = useState(
-    typeof window !== 'undefined' ? window.innerWidth : 1024
-  );
-  useEffect(() => {
-    const handler = () => setWidth(window.innerWidth);
-    window.addEventListener('resize', handler);
-    return () => window.removeEventListener('resize', handler);
-  }, []);
-  return width;
-}
 
 export function News() {
   const [news, setNews] = useState<Article[]>([]);

--- a/frontend/components/PlayerProfile.tsx
+++ b/frontend/components/PlayerProfile.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { BackBar, Flag } from "./Shared";
+import { useWindowWidth } from "@/hooks/useWindowWidth";
 import type { FotmobPlayerDetail } from "@/types/fotmob";
 import { PlayerProfileSkeleton } from "@/components/skeleton/TeamPagesSkeleton";
 
@@ -11,6 +12,10 @@ export function PlayerProfile({ playerId, teamCode }: { playerId: string; teamCo
   const [detail, setDetail] = useState<FotmobPlayerDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const width = useWindowWidth();
+  const isMobile = width < 640;
+  const isTablet = width < 1024;
+  const pad = isMobile ? '16px' : isTablet ? '24px' : '40px';
 
   useEffect(() => {
     if (!upper) {
@@ -54,7 +59,7 @@ export function PlayerProfile({ playerId, teamCode }: { playerId: string; teamCo
 
       <div
         style={{
-          padding: "40px 24px 72px",
+          padding: `40px ${pad} 72px`,
           maxWidth: 1040,
           width: "100%",
           margin: "0 auto",
@@ -80,8 +85,8 @@ export function PlayerProfile({ playerId, teamCode }: { playerId: string; teamCo
           <div
             style={{
               display: "grid",
-              gridTemplateColumns: "minmax(0, 1fr) minmax(0, 1fr)",
-              gap: 48,
+              gridTemplateColumns: isMobile ? "1fr" : "minmax(0, 1fr) minmax(0, 1fr)",
+              gap: isMobile ? 32 : 48,
               alignItems: "start",
             }}
           >
@@ -113,7 +118,7 @@ export function PlayerProfile({ playerId, teamCode }: { playerId: string; teamCo
               <div
                 style={{
                   display: "grid",
-                  gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))",
+                  gridTemplateColumns: "repeat(auto-fill, minmax(min(160px, 100%), 1fr))",
                   gap: 14,
                   marginTop: 14,
                 }}

--- a/frontend/components/StadiumView.tsx
+++ b/frontend/components/StadiumView.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useWindowWidth } from '@/hooks/useWindowWidth';
 import Link from 'next/link';
 import { stadiums } from '@/lib/data';
 import { BackBar, Stat } from './Shared';
@@ -33,6 +34,10 @@ export function StadiumView({ id }: { id: string }) {
   const s = stadiums.find((x) => x.id === id);
   const [enrichment, setEnrichment] = useState<StadiumEnrichment | null>(null);
   const [imgError, setImgError] = useState(false);
+  const width = useWindowWidth();
+  const isMobile = width < 640;
+  const isTablet = width < 1024;
+  const pad = isMobile ? '16px' : isTablet ? '24px' : '56px';
 
   useEffect(() => {
     fetch(`/api/stadium/${id}`)
@@ -72,7 +77,7 @@ export function StadiumView({ id }: { id: string }) {
         </div>
       )}
 
-      <div style={{ padding: heroImg ? '0 56px 48px' : '48px 56px', display: 'grid', gridTemplateColumns: '1fr 380px', gap: 48, alignItems: 'start' }}>
+      <div style={{ padding: heroImg ? `0 ${pad} 48px` : `48px ${pad}`, display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1fr 380px', gap: isMobile ? 0 : 48, alignItems: 'start' }}>
         {/* Left: info column */}
         <div>
           {/* Name + description */}
@@ -93,7 +98,7 @@ export function StadiumView({ id }: { id: string }) {
           </div>
 
           {/* Stats row */}
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 24, borderTop: '1px solid var(--rule)', paddingTop: 22, marginBottom: 48 }}>
+          <div style={{ display: 'grid', gridTemplateColumns: isMobile ? 'repeat(2, 1fr)' : 'repeat(4, 1fr)', gap: 24, borderTop: '1px solid var(--rule)', paddingTop: 22, marginBottom: 48 }}>
             <Stat n={s.capacity.toLocaleString()} l="Capacity" />
             <Stat n={String(s.opened)} l="Opened" />
             <Stat n={s.surface} l="Surface" />
@@ -112,15 +117,15 @@ export function StadiumView({ id }: { id: string }) {
             ) : (
               <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
                 {sortedMatches.map((m) => (
-                  <MatchRow key={m.id} match={m} />
+                  <MatchRow key={m.id} match={m} isMobile={isMobile} />
                 ))}
               </div>
             )}
           </div>
         </div>
 
-        {/* Right: sticky mini-map */}
-        <div style={{ position: 'sticky', top: 80 }}>
+        {/* Right: mini-map */}
+        <div style={isMobile ? {} : { position: 'sticky', top: 80 }}>
           <div style={{ height: 420, borderRadius: 16, overflow: 'hidden', border: '1px solid var(--rule)', boxShadow: '0 4px 24px rgba(14,22,38,0.08)' }}>
             <StadiumMiniMap lat={s.lat} lng={s.lng} name={realName} />
           </div>
@@ -133,7 +138,7 @@ export function StadiumView({ id }: { id: string }) {
   );
 }
 
-function MatchRow({ match }: { match: MatchData }) {
+function MatchRow({ match, isMobile }: { match: MatchData; isMobile: boolean }) {
   const isLive = match.state === 'in';
   const isFT = match.state === 'post';
   const isPre = match.state === 'pre';
@@ -149,10 +154,10 @@ function MatchRow({ match }: { match: MatchData }) {
     <Link href={`/match/${match.id}`} style={{ textDecoration: 'none' }}>
       <div style={{
         display: 'grid',
-        gridTemplateColumns: '100px 1fr auto 1fr 100px',
+        gridTemplateColumns: isMobile ? '1fr auto 1fr' : '100px 1fr auto 1fr 100px',
         alignItems: 'center',
-        gap: 12,
-        padding: '14px 20px',
+        gap: isMobile ? 8 : 12,
+        padding: isMobile ? '12px 14px' : '14px 20px',
         borderRadius: 10,
         border: '1px solid var(--rule)',
         background: 'var(--paper-2)',
@@ -162,18 +167,20 @@ function MatchRow({ match }: { match: MatchData }) {
         onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--paper-3, var(--rule-soft))')}
         onMouseLeave={(e) => (e.currentTarget.style.background = 'var(--paper-2)')}
       >
-        {/* Date / status */}
-        <div>
-          <div className="mono" style={{ fontSize: 10, color: isLive ? 'var(--live)' : 'var(--ink-3)', letterSpacing: '0.1em', fontWeight: isLive ? 700 : 400 }}>
-            {isLive ? '● LIVE' : isFT ? 'FULL TIME' : dateStr}
+        {/* Date / status — hidden on mobile (3-col layout omits this) */}
+        {!isMobile && (
+          <div>
+            <div className="mono" style={{ fontSize: 10, color: isLive ? 'var(--live)' : 'var(--ink-3)', letterSpacing: '0.1em', fontWeight: isLive ? 700 : 400 }}>
+              {isLive ? '● LIVE' : isFT ? 'FULL TIME' : dateStr}
+            </div>
+            {isPre && (
+              <div className="mono" style={{ fontSize: 10, color: 'var(--ink-3)', marginTop: 2 }}>{timeStr}</div>
+            )}
+            {isFT && match.statusDetail && (
+              <div className="mono" style={{ fontSize: 10, color: 'var(--ink-3)', marginTop: 2 }}>{match.statusDetail}</div>
+            )}
           </div>
-          {isPre && (
-            <div className="mono" style={{ fontSize: 10, color: 'var(--ink-3)', marginTop: 2 }}>{timeStr}</div>
-          )}
-          {isFT && match.statusDetail && (
-            <div className="mono" style={{ fontSize: 10, color: 'var(--ink-3)', marginTop: 2 }}>{match.statusDetail}</div>
-          )}
-        </div>
+        )}
 
         {/* Home team */}
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, justifyContent: 'flex-end' }}>
@@ -192,8 +199,10 @@ function MatchRow({ match }: { match: MatchData }) {
           <span style={{ fontSize: 14, fontWeight: 600, color: 'var(--ink)' }}>{away?.name ?? '—'}</span>
         </div>
 
-        {/* Arrow */}
-        <div style={{ textAlign: 'right', color: 'var(--ink-3)', fontSize: 14 }}>→</div>
+        {/* Arrow — hidden on mobile */}
+        {!isMobile && (
+          <div style={{ textAlign: 'right', color: 'var(--ink-3)', fontSize: 14 }}>→</div>
+        )}
       </div>
     </Link>
   );

--- a/frontend/components/Standings.tsx
+++ b/frontend/components/Standings.tsx
@@ -7,6 +7,7 @@ import type { StandingsGroupBlock, GroupStandingEntry } from '@/types/espn';
 import { teamCodeFromDisplayName } from '@/lib/team-codes';
 import { StandingsSkeleton } from '@/components/skeleton/TeamPagesSkeleton';
 import { teams } from '@/lib/data';
+import { useWindowWidth } from '@/hooks/useWindowWidth';
 
 // ── Colour helpers ────────────────────────────────────────────────────────────
 
@@ -29,19 +30,6 @@ interface ThirdPlaceEntry extends GroupStandingEntry {
   groupName: string;
 }
 
-// ── Responsive hook ───────────────────────────────────────────────────────────
-
-function useWindowWidth() {
-  const [width, setWidth] = useState(
-    typeof window !== 'undefined' ? window.innerWidth : 1024
-  );
-  useEffect(() => {
-    const handler = () => setWidth(window.innerWidth);
-    window.addEventListener('resize', handler);
-    return () => window.removeEventListener('resize', handler);
-  }, []);
-  return width;
-}
 
 // ── Page ──────────────────────────────────────────────────────────────────────
 

--- a/frontend/components/Stats.tsx
+++ b/frontend/components/Stats.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { Flag, Big } from './Shared';
+import { useWindowWidth } from '@/hooks/useWindowWidth';
 
 interface TopScorer {
   rank: number;
@@ -142,6 +143,10 @@ export function Stats() {
   const [data, setData] = useState<StatsData | null>(null);
   const [loading, setLoading] = useState(true);
   const [empty, setEmpty] = useState(false);
+  const width = useWindowWidth();
+  const isMobile = width < 640;
+  const isTablet = width < 1024;
+  const pad = isMobile ? '16px' : isTablet ? '24px' : '56px';
 
   useEffect(() => {
     let isMounted = true;
@@ -199,14 +204,14 @@ export function Stats() {
   if (empty || !data) {
     return (
       <div className="screen">
-        <div style={{ padding: '40px 56px 24px', borderBottom: '1px solid var(--rule)' }}>
+        <div style={{ padding: `40px ${pad} 24px`, borderBottom: '1px solid var(--rule)' }}>
           <div className="eyebrow">Statistics · Tournament so far</div>
-          <div className="headline" style={{ fontSize: 64, marginTop: 8 }}>
+          <div className="headline" style={{ fontSize: isMobile ? 36 : isTablet ? 48 : 64, marginTop: 8 }}>
             The numbers <em>behind the noise.</em>
           </div>
         </div>
         <div style={{
-          padding: '80px 56px',
+          padding: `60px ${pad}`,
           display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
           gap: 20, textAlign: 'center',
         }}>
@@ -238,14 +243,14 @@ export function Stats() {
 
   return (
     <div className="screen">
-      <div style={{ padding: '40px 56px 24px', borderBottom: '1px solid var(--rule)' }}>
+      <div style={{ padding: `40px ${pad} 24px`, borderBottom: '1px solid var(--rule)' }}>
         <div className="eyebrow">Statistics · Tournament so far</div>
-        <div className="headline" style={{ fontSize: 64, marginTop: 8 }}>
+        <div className="headline" style={{ fontSize: isMobile ? 36 : isTablet ? 48 : 64, marginTop: 8 }}>
           The numbers <em>behind the noise.</em>
         </div>
       </div>
 
-      <div style={{ padding: '40px 56px 64px', display: 'grid', gridTemplateColumns: '2fr 1fr', gap: 48 }}>
+      <div style={{ padding: `40px ${pad} 64px`, display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '2fr 1fr', gap: isMobile ? 32 : 48 }}>
         {/* ── Top Scorers ── */}
         <div>
           <div style={{
@@ -259,25 +264,31 @@ export function Stats() {
             {data.topScorers.map((s) => (
               <div key={s.player + s.team} style={{
                 display: 'grid',
-                gridTemplateColumns: '36px 32px auto 1fr auto auto auto',
-                alignItems: 'center', gap: 14, padding: '14px 0',
+                gridTemplateColumns: isMobile ? '28px 24px 1fr auto' : '36px 32px auto 1fr auto auto auto',
+                alignItems: 'center', gap: isMobile ? 10 : 14, padding: '14px 0',
                 borderTop: '1px solid var(--rule-soft)',
               }}>
-                <div className="serif tnum" style={{ fontSize: 22, color: s.rank === 1 ? 'var(--pulse)' : 'var(--ink-2)' }}>
+                <div className="serif tnum" style={{ fontSize: isMobile ? 16 : 22, color: s.rank === 1 ? 'var(--pulse)' : 'var(--ink-2)' }}>
                   {String(s.rank).padStart(2, '0')}
                 </div>
                 <Link href={`/team/${s.team}`} style={{ display: 'contents' }}>
-                  <Flag code={s.team} w={24} h={16} />
+                  <Flag code={s.team} w={isMobile ? 20 : 24} h={isMobile ? 13 : 16} />
                 </Link>
-                <div className="serif" style={{ fontSize: 18 }}>{s.player}</div>
-                <div style={{ height: 8, background: 'var(--rule-soft)', borderRadius: 4, position: 'relative', overflow: 'hidden' }}>
-                  <div style={{ position: 'absolute', inset: 0, width: `${(s.goals / maxGoals) * 100}%`, background: 'var(--pulse)' }} />
-                </div>
-                <div className="mono tnum" style={{ fontSize: 11, color: 'var(--ink-3)', width: 56, textAlign: 'right' }}>
-                  {s.xg > 0 ? `xG ${s.xg.toFixed(1)}` : `MP ${s.mp}`}
-                </div>
-                <div className="mono tnum" style={{ fontSize: 11, color: 'var(--ink-3)', width: 30, textAlign: 'right' }}>A {s.assists}</div>
-                <div className="serif tnum" style={{ fontSize: 24, width: 40, textAlign: 'right' }}>{s.goals}</div>
+                <div className="serif" style={{ fontSize: isMobile ? 15 : 18 }}>{s.player}</div>
+                {!isMobile && (
+                  <div style={{ height: 8, background: 'var(--rule-soft)', borderRadius: 4, position: 'relative', overflow: 'hidden' }}>
+                    <div style={{ position: 'absolute', inset: 0, width: `${(s.goals / maxGoals) * 100}%`, background: 'var(--pulse)' }} />
+                  </div>
+                )}
+                {!isMobile && (
+                  <div className="mono tnum" style={{ fontSize: 11, color: 'var(--ink-3)', width: 56, textAlign: 'right' }}>
+                    {s.xg > 0 ? `xG ${s.xg.toFixed(1)}` : `MP ${s.mp}`}
+                  </div>
+                )}
+                {!isMobile && (
+                  <div className="mono tnum" style={{ fontSize: 11, color: 'var(--ink-3)', width: 30, textAlign: 'right' }}>A {s.assists}</div>
+                )}
+                <div className="serif tnum" style={{ fontSize: isMobile ? 20 : 24, width: isMobile ? 32 : 40, textAlign: 'right' }}>{s.goals}</div>
               </div>
             ))}
           </div>
@@ -336,7 +347,7 @@ export function Stats() {
 
           <div style={{ background: 'var(--ink)', color: 'var(--paper)', padding: 22, borderRadius: 12 }}>
             <div className="mono" style={{ fontSize: 10, letterSpacing: '0.18em', opacity: 0.65 }}>TOURNAMENT TOTALS</div>
-            <div style={{ marginTop: 14, display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 18 }}>
+            <div style={{ marginTop: 14, display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 18 }}>
               <Big n={data.totals.goals > 0 ? String(data.totals.goals) : '—'} l="Goals" />
               <Big n={data.totals.avgPerMatch > 0 ? String(data.totals.avgPerMatch) : '—'} l="Avg per match" />
               <Big n={String(data.totals.teams)} l="Teams" />

--- a/frontend/components/TeamHub.tsx
+++ b/frontend/components/TeamHub.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { BackBar, Flag } from "./Shared";
+import { useWindowWidth } from "@/hooks/useWindowWidth";
 import type { FotmobFixture, FotmobSquadMember, FotmobTeamProfile } from "@/types/fotmob";
 import { getTeamMapEntry } from "@/lib/fotmob/team-map";
 import { TeamHubHeaderSkeleton, TeamHubSkeleton } from "@/components/skeleton/TeamPagesSkeleton";
@@ -460,6 +461,10 @@ function HeroStandingBadge({ row }: { row: StandingRow }) {
 export function TeamHub({ code }: { code: string }) {
   const upper = code.toUpperCase();
   const mapEntry = getTeamMapEntry(upper);
+  const width = useWindowWidth();
+  const isMobile = width < 640;
+  const isTablet = width < 1024;
+  const pad = isMobile ? '16px' : isTablet ? '24px' : '40px';
 
   const [profile, setProfile] = useState<FotmobTeamProfile | null>(null);
   const [loading, setLoading] = useState(true);
@@ -514,7 +519,7 @@ export function TeamHub({ code }: { code: string }) {
     return (
       <div className="screen">
         <BackBar label="TEAM" />
-        <div style={{ padding: "40px 56px" }}>
+        <div style={{ padding: `40px ${pad}` }}>
           <div className="serif" style={{ fontSize: 28 }}>Unknown team: {upper}</div>
         </div>
       </div>
@@ -532,7 +537,7 @@ export function TeamHub({ code }: { code: string }) {
       <BackBar label={`TEAM · ${upper}`} />
 
       {/* Hero */}
-      <div style={{ padding: "32px 40px 28px", borderBottom: "1px solid var(--rule)" }}>
+      <div style={{ padding: isMobile ? `24px 16px 20px` : `32px ${pad} 28px`, borderBottom: "1px solid var(--rule)" }}>
         <div style={{ display: "flex", alignItems: "flex-start", gap: 24, flexWrap: "wrap" }}>
           <div style={{ flexShrink: 0 }}><Flag code={upper} w={80} h={54} /></div>
           <div style={{ flex: 1, minWidth: 200 }}>
@@ -578,10 +583,12 @@ export function TeamHub({ code }: { code: string }) {
 
       {/* Tab bar */}
       <div style={{
-        padding: "0 40px",
+        padding: isMobile ? "0 8px" : `0 ${pad}`,
         borderBottom: "1px solid var(--rule)",
         display: "flex",
         gap: 0,
+        overflowX: "auto",
+        scrollbarWidth: "none",
       }}>
         {TABS.map(t => (
           <button
@@ -608,7 +615,7 @@ export function TeamHub({ code }: { code: string }) {
       </div>
 
       {/* Tab content */}
-      <div style={{ padding: "32px 40px 80px" }}>
+      <div style={{ padding: isMobile ? `24px 16px 64px` : `32px ${pad} 80px` }}>
         {loading && <TeamHubSkeleton />}
 
         {!loading && error && (

--- a/frontend/hooks/useWindowWidth.ts
+++ b/frontend/hooks/useWindowWidth.ts
@@ -15,5 +15,13 @@ export function useWindowWidth() {
 }
 
 export function useIsMobile(breakpoint = 640): boolean {
-  return useWindowWidth() < breakpoint;
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
+    setIsMobile(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, [breakpoint]);
+  return isMobile;
 }

--- a/frontend/hooks/useWindowWidth.ts
+++ b/frontend/hooks/useWindowWidth.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function useWindowWidth() {
+  const [width, setWidth] = useState(
+    typeof window !== 'undefined' ? window.innerWidth : 1024
+  );
+  useEffect(() => {
+    const handler = () => setWidth(window.innerWidth);
+    window.addEventListener('resize', handler);
+    return () => window.removeEventListener('resize', handler);
+  }, []);
+  return width;
+}
+
+export function useIsMobile(breakpoint = 640): boolean {
+  return useWindowWidth() < breakpoint;
+}


### PR DESCRIPTION
## Summary

- **Git pull** — merged 2 new upstream commits (MyWorldCup, Standings/News/MatchesList updates) before starting
- **Shared hook** — extracted `useWindowWidth` + `useIsMobile` to `frontend/hooks/useWindowWidth.ts`, removing 5 duplicate inline implementations across pages and components
- **12 components fixed** for mobile (≤640px) and tablet (≤1024px) viewpoints — no page now has hardcoded multi-column grids without breakpoints
- **globals.css** — added `@media (max-width: 640px)` block for bracket hero, screen overflow guard

## What changed per page/component

| Component | Problem | Fix |
|-----------|---------|-----|
| `Stats` | `2fr 1fr` grid, `56px` padding, `fontSize: 64` | Single column on mobile, adaptive padding + font sizes; scorer row hides bar/xG columns |
| `MatchDetail` | `1fr auto 1fr` team display | Stacks home → score → away vertically on mobile |
| `StadiumView` | `1fr 380px` sticky sidebar | Single column; sticky removed on mobile; stat cards `4→2` cols; match rows `5→3` cols |
| `CountryView` | `2fr 1fr` hero + `1fr 1fr` body, `fontSize: 120` | Responsive font (120→64px), all grids collapse to 1-col |
| `PlayerProfile` | `1fr 1fr` with `48px` gap | Single column on mobile |
| `MyWorldCup` | `1fr 1fr` with `56px` gap, `maxHeight: 560` capped | Single column; height cap removed on mobile |
| `TeamHub` | Large padding, non-scrollable tab bar | Responsive padding everywhere; tab bar gets `overflow-x: auto` |
| `MatchesList` | Local `useWindowWidth` duplicate | Consolidated to shared hook (already responsive from prior PR) |
| `Standings` | Local `useWindowWidth` duplicate | Consolidated to shared hook |
| `News` | Local `useWindowWidth` duplicate | Consolidated to shared hook |
| `admin/page.tsx` | Inline `useIsMobile` duplicate | Imports from shared hook |
| `match/[id]/page.tsx` | Inline `useIsMobile` duplicate | Imports from shared hook |
| `test-mls/[slug]/page.tsx` | Inline `useIsMobile` duplicate | Imports from shared hook |

## Test plan

- [ ] Run `npm run dev` in `/frontend`
- [ ] Open DevTools → toggle device toolbar
- [ ] Test at 375px (iPhone SE), 390px (iPhone 14), 768px (iPad), 1024px (iPad landscape)
- [ ] Visit every route: `/`, `/matches`, `/standings`, `/bracket`, `/news`, `/stats`, `/mywc`, `/admin`, `/match/[id]`, `/player/[id]`, `/team/[code]`, `/stadium/[id]`, `/country/[code]`
- [ ] Verify: no horizontal overflow, readable text, no cramped 2-column layouts at 375px
- [ ] `npx tsc --noEmit` passes ✅ (verified before commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)